### PR TITLE
"type": "module" 指定を消す

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "homepage": "https://ChenCMD.github.io/shapes-generator-v2",
-  "type": "module",
   "dependencies": {
     "@primer/octicons-react": "^16.2.0",
     "bootstrap": "^5.0.1",


### PR DESCRIPTION
This closes #6, #9.

jestのpresetとして指定されている `ts-jest/presets/default-esm` では、`.ts` と `.tsx` をすべてESMとして扱うようにすでに設定されてるっぽいので、"type"を指定せずともすべてをESMとして扱ってくれるぽい。JestはESMに対するexperimental supportがある(mock testに関しては未実装)らしいので、一応これで全部動くはず。

`yarn build` が通ることと、 `yarn jest` が以下のようなテストコードを `src/types/Points.test.ts` に置いて正しく動作することは確認済み。

```TS
import * as P from './Point';

test('', () => {
  const p: P.Point = ({
    x: 1.0,
    y: 1.0
  });
  
  expect(p.x).toBe(1.0);
});
```